### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the npm_lazy cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: recipes/server.rb:34:4 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper`
 ## 2.0.6 - *2023-02-14*
 
 ## 2.0.5 - *2023-02-14*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the npm_lazy cookbook.
 ## Unreleased
 
 - resolved cookstyle error: recipes/server.rb:34:4 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper`
+- Require Chef 16
+
 ## 2.0.6 - *2023-02-14*
 
 ## 2.0.5 - *2023-02-14*

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email 'help@sous-chefs.org'
 license 'Apache-2.0'
 description 'Installs and configures the npm_lazy application for caching NPM registry calls'
 version '2.0.6'
+source_url 'https://github.com/sous-chefs/npm_lazy'
+issues_url 'https://github.com/sous-chefs/npm_lazy/issues'
+chef_version '>= 16'
 
 supports 'ubuntu'
 supports 'debian'
 
 depends 'nodejs', '>= 3.0'
 
-source_url 'https://github.com/sous-chefs/npm_lazy'
-issues_url 'https://github.com/sous-chefs/npm_lazy/issues'
-chef_version '>= 12.11'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -31,7 +31,7 @@ template '/etc/npm_lazy-config.js' do
   notifies :restart, 'service[npm_lazy]'
 end
 
-if node['init_package'] == 'systemd'
+if systemd?
   systemd_unit 'npm_lazy.service' do
     content(Unit: {
               Description: 'NPM Lazy - A lazy local cache for NPM to make your local deploys faster',


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with recipes/server.rb

 - 34:4 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper` - Chef Infra Client 15.5 and later include a `systemd?` helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)