### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the npm_lazy cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: metadata.rb:15:1 convention: `Layout/TrailingEmptyLines`
 ## 3.0.0 - *2023-02-15*
 
 - resolved cookstyle error: recipes/server.rb:34:4 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper`

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,3 @@ supports 'ubuntu'
 supports 'debian'
 
 depends 'nodejs', '>= 3.0'
-


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with metadata.rb

 - 15:1 convention: `Layout/TrailingEmptyLines` - 1 trailing blank lines detected. (https://rubystyle.guide#newline-eof)